### PR TITLE
fix: Calling a constructor that takes an array argument

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -24,7 +24,7 @@ import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.{IsPrivate, IsPublic}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker._
 import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor.mkDescriptor
-import ca.uwaterloo.flix.language.phase.jvm.JvmName.{DevFlixRuntime, JavaLang, JavaUtil, IntFunction, MethodDescriptor, RootPackage}
+import ca.uwaterloo.flix.language.phase.jvm.JvmName.{DevFlixRuntime, JavaLang, JavaUtil, MethodDescriptor, RootPackage}
 import org.objectweb.asm.Opcodes
 
 /**
@@ -149,25 +149,69 @@ object BackendObjType {
 
   case class Arrow(args: List[BackendType], result: BackendType) extends BackendObjType {
 
+
     /**
-      * Returns true if the type is Int32 -> JavaObject.
+      * Represents a function interface from `java.util.function`.
       */
-    def intFunction(): Boolean = {
+    sealed trait FunctionInterface {
+      /**
+        * The JvmName of the interface.
+        */
+      def jvmName: JvmName = this match {
+        case IntFunction => JvmName.IntFunction
+        case IntUnaryOperator => JvmName.IntUnaryOperator
+      }
+
+      /**
+        * The required method of the interface.
+        * These methods should do the same as a non-tail call in genExpression.
+        */
+      def functionMethod: InstanceMethod = this match {
+        case IntFunction => InstanceMethod(this.jvmName, IsPublic, IsFinal, "apply",
+          mkDescriptor(BackendType.Int32)(JavaObject.toTpe),
+          Some(
+            thisLoad() ~
+              DUP() ~ ILOAD(1) ~ PUTFIELD(ArgField(0)) ~
+              INVOKEVIRTUAL(continuation.UnwindMethod) ~ ARETURN()
+          ))
+        case IntUnaryOperator => InstanceMethod(this.jvmName, IsPublic, IsFinal, "applyAsInt",
+          mkDescriptor(BackendType.Int32)(BackendType.Int32),
+          Some(
+            thisLoad() ~
+              DUP() ~ ILOAD(1) ~ PUTFIELD(ArgField(0)) ~
+              INVOKEVIRTUAL(continuation.UnwindMethod) ~ IRETURN()
+          ))
+      }
+    }
+
+    // Int32 -> JavaObject
+    case object IntFunction extends FunctionInterface
+
+    // Int32 -> Int32
+    case object IntUnaryOperator extends FunctionInterface
+
+    /**
+      * Returns the specialized java function interface of the function type.
+      */
+    def specialization(): Option[FunctionInterface] = {
       (args, result) match {
         case (BackendType.Int32 :: Nil, BackendType.Reference(BackendObjType.JavaObject)) =>
-          true
-        case _ => false
+          Some(IntFunction)
+        case (BackendType.Int32 :: Nil, BackendType.Int32) =>
+          Some(IntUnaryOperator)
+        case _ => None
       }
     }
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val interfaces = if (intFunction()) List(IntFunction) else Nil
+      val specializedInterface = specialization()
+      val interfaces = specializedInterface.toList.map(_.jvmName)
 
       val cm = ClassMaker.mkAbstractClass(this.jvmName, superClass = continuation.jvmName, interfaces)
 
       cm.mkConstructor(Constructor)
       args.indices.foreach(argIndex => cm.mkField(ArgField(argIndex)))
-      if (intFunction()) cm.mkMethod(IntFunctionApplyMethod)
+      specializedInterface.foreach(i => cm.mkMethod(i.functionMethod))
       cm.mkMethod(ToStringMethod)
 
       cm.closeClassMaker()
@@ -180,13 +224,6 @@ object BackendObjType {
     ))
 
     def ArgField(index: Int): InstanceField = InstanceField(this.jvmName, IsPublic, NotFinal, s"arg$index", args(index))
-
-    def IntFunctionApplyMethod: InstanceMethod = InstanceMethod(this.jvmName, IsPublic, IsFinal, "apply",
-      mkDescriptor(BackendType.Int32)(JavaObject.toTpe),
-      Some(
-        // alias for unwind
-        thisLoad() ~ INVOKEVIRTUAL(continuation.UnwindMethod) ~ ARETURN()
-      ))
 
     def ToStringMethod: InstanceMethod = {
       val argString = args match {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -803,24 +803,12 @@ object GenExpression {
       visitor.visitTypeInsn(NEW, declaration)
       // Duplicate the reference since the first argument for a constructor call is the reference to the object
       visitor.visitInsn(DUP)
-      // Evaluate arguments left-to-right and push them onto the stack.
-      for (arg <- args) {
-        compileExpression(arg, visitor, currentClass, lenv0, entryPoint)
-        // Cast the argument to the right type.
-        arg.tpe match {
-          // NB: This is not exhaustive. In the new backend we should handle all types, including multidim arrays.
-          case MonoType.Array(MonoType.Float32) => visitor.visitTypeInsn(CHECKCAST, "[F")
-          case MonoType.Array(MonoType.Float64) => visitor.visitTypeInsn(CHECKCAST, "[D")
-          case MonoType.Array(MonoType.Int8) => visitor.visitTypeInsn(CHECKCAST, "[B")
-          case MonoType.Array(MonoType.Int16) => visitor.visitTypeInsn(CHECKCAST, "[S")
-          case MonoType.Array(MonoType.Int32) => visitor.visitTypeInsn(CHECKCAST, "[I")
-          case MonoType.Array(MonoType.Int64) => visitor.visitTypeInsn(CHECKCAST, "[J")
-          case MonoType.Native(clazz) =>
-            val argType = asm.Type.getInternalName(clazz)
-            visitor.visitTypeInsn(CHECKCAST, argType)
-          case _ => // nop
-        }
-      }
+      // Retrieve the signature.
+      val signature = constructor.getParameterTypes
+
+      // Invoke the constructor
+      compileInvoke(visitor, args, signature, currentClass, lenv0, entryPoint)
+
       // Call the constructor
       visitor.visitMethodInsn(INVOKESPECIAL, declaration, "<init>", descriptor, false)
 
@@ -836,25 +824,9 @@ object GenExpression {
       // Retrieve the signature.
       val signature = method.getParameterTypes
 
-      // Evaluate arguments left-to-right and push them onto the stack.
-      for ((arg, argType) <- args.zip(signature)) {
-        compileExpression(arg, visitor, currentClass, lenv0, entryPoint)
-        if (!argType.isPrimitive) {
-          // NB: Really just a hack because the backend does not support array JVM types properly.
-          visitor.visitTypeInsn(CHECKCAST, asm.Type.getInternalName(argType))
-        } else {
-          arg.tpe match {
-            // NB: This is not exhaustive. In the new backend we should handle all types, including multidim arrays.
-            case MonoType.Array(MonoType.Float32) => visitor.visitTypeInsn(CHECKCAST, "[F")
-            case MonoType.Array(MonoType.Float64) => visitor.visitTypeInsn(CHECKCAST, "[D")
-            case MonoType.Array(MonoType.Int8) => visitor.visitTypeInsn(CHECKCAST, "[B")
-            case MonoType.Array(MonoType.Int16) => visitor.visitTypeInsn(CHECKCAST, "[S")
-            case MonoType.Array(MonoType.Int32) => visitor.visitTypeInsn(CHECKCAST, "[I")
-            case MonoType.Array(MonoType.Int64) => visitor.visitTypeInsn(CHECKCAST, "[J")
-            case _ => // nop
-          }
-        }
-      }
+      // Invoke the method
+      compileInvoke(visitor, args, signature, currentClass, lenv0, entryPoint)
+
       val declaration = asm.Type.getInternalName(method.getDeclaringClass)
       val name = method.getName
       val descriptor = asm.Type.getMethodDescriptor(method)
@@ -874,24 +846,7 @@ object GenExpression {
     case Expression.InvokeStaticMethod(method, args, _, loc) =>
       addSourceLine(visitor, loc)
       val signature = method.getParameterTypes
-      for ((arg, argType) <- args.zip(signature)) {
-        compileExpression(arg, visitor, currentClass, lenv0, entryPoint)
-        if (!argType.isPrimitive) {
-          // NB: Really just a hack because the backend does not support array JVM types properly.
-          visitor.visitTypeInsn(CHECKCAST, asm.Type.getInternalName(argType))
-        } else {
-          arg.tpe match {
-            // NB: This is not exhaustive. In the new backend we should handle all types, including multidim arrays.
-            case MonoType.Array(MonoType.Float32) => visitor.visitTypeInsn(CHECKCAST, "[F")
-            case MonoType.Array(MonoType.Float64) => visitor.visitTypeInsn(CHECKCAST, "[D")
-            case MonoType.Array(MonoType.Int8) => visitor.visitTypeInsn(CHECKCAST, "[B")
-            case MonoType.Array(MonoType.Int16) => visitor.visitTypeInsn(CHECKCAST, "[S")
-            case MonoType.Array(MonoType.Int32) => visitor.visitTypeInsn(CHECKCAST, "[I")
-            case MonoType.Array(MonoType.Int64) => visitor.visitTypeInsn(CHECKCAST, "[J")
-            case _ => // nop
-          }
-        }
-      }
+      compileInvoke(visitor, args, signature, currentClass, lenv0, entryPoint)
       val declaration = asm.Type.getInternalName(method.getDeclaringClass)
       val name = method.getName
       val descriptor = asm.Type.getMethodDescriptor(method)
@@ -1690,4 +1645,25 @@ object GenExpression {
     visitor.visitLineNumber(loc.beginLine, label)
   }
 
+  private def compileInvoke(visitor: MethodVisitor, args: List[Expression], signature: Array[Class[_ <: Object]], currentClass: JvmType.Reference, lenv0: Map[Symbol.LabelSym, Label], entryPoint: Label)(implicit root: Root, flix: Flix): Unit = {
+    // Evaluate arguments left-to-right and push them onto the stack.
+    for ((arg, argType) <- args.zip(signature)) {
+      compileExpression(arg, visitor, currentClass, lenv0, entryPoint)
+      if (!argType.isPrimitive) {
+        // NB: Really just a hack because the backend does not support array JVM types properly.
+        visitor.visitTypeInsn(CHECKCAST, asm.Type.getInternalName(argType))
+      } else {
+        arg.tpe match {
+          // NB: This is not exhaustive. In the new backend we should handle all types, including multidim arrays.
+          case MonoType.Array(MonoType.Float32) => visitor.visitTypeInsn(CHECKCAST, "[F")
+          case MonoType.Array(MonoType.Float64) => visitor.visitTypeInsn(CHECKCAST, "[D")
+          case MonoType.Array(MonoType.Int8) => visitor.visitTypeInsn(CHECKCAST, "[B")
+          case MonoType.Array(MonoType.Int16) => visitor.visitTypeInsn(CHECKCAST, "[S")
+          case MonoType.Array(MonoType.Int32) => visitor.visitTypeInsn(CHECKCAST, "[I")
+          case MonoType.Array(MonoType.Int64) => visitor.visitTypeInsn(CHECKCAST, "[J")
+          case _ => // nop
+        }
+      }
+    }
+  }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -806,8 +806,7 @@ object GenExpression {
       // Retrieve the signature.
       val signature = constructor.getParameterTypes
 
-      // Invoke the constructor
-      compileInvoke(visitor, args, signature, currentClass, lenv0, entryPoint)
+      pushArgs(visitor, args, signature, currentClass, lenv0, entryPoint)
 
       // Call the constructor
       visitor.visitMethodInsn(INVOKESPECIAL, declaration, "<init>", descriptor, false)
@@ -824,8 +823,7 @@ object GenExpression {
       // Retrieve the signature.
       val signature = method.getParameterTypes
 
-      // Invoke the method
-      compileInvoke(visitor, args, signature, currentClass, lenv0, entryPoint)
+      pushArgs(visitor, args, signature, currentClass, lenv0, entryPoint)
 
       val declaration = asm.Type.getInternalName(method.getDeclaringClass)
       val name = method.getName
@@ -846,7 +844,7 @@ object GenExpression {
     case Expression.InvokeStaticMethod(method, args, _, loc) =>
       addSourceLine(visitor, loc)
       val signature = method.getParameterTypes
-      compileInvoke(visitor, args, signature, currentClass, lenv0, entryPoint)
+      pushArgs(visitor, args, signature, currentClass, lenv0, entryPoint)
       val declaration = asm.Type.getInternalName(method.getDeclaringClass)
       val name = method.getName
       val descriptor = asm.Type.getMethodDescriptor(method)
@@ -1645,7 +1643,10 @@ object GenExpression {
     visitor.visitLineNumber(loc.beginLine, label)
   }
 
-  private def compileInvoke(visitor: MethodVisitor, args: List[Expression], signature: Array[Class[_ <: Object]], currentClass: JvmType.Reference, lenv0: Map[Symbol.LabelSym, Label], entryPoint: Label)(implicit root: Root, flix: Flix): Unit = {
+  /**
+    * Pushes arguments onto the stack ready to invoke a method
+    */
+  private def pushArgs(visitor: MethodVisitor, args: List[Expression], signature: Array[Class[_ <: Object]], currentClass: JvmType.Reference, lenv0: Map[Symbol.LabelSym, Label], entryPoint: Label)(implicit root: Root, flix: Flix): Unit = {
     // Evaluate arguments left-to-right and push them onto the stack.
     for ((arg, argType) <- args.zip(signature)) {
       compileExpression(arg, visitor, currentClass, lenv0, entryPoint)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
@@ -74,6 +74,7 @@ object JvmName {
 
   val JavaLang: List[String] = List("java", "lang")
   val JavaUtil: List[String] = List("java", "util")
+  val JavaUtilFunction: List[String] = JavaUtil ::: List("function")
 
   val AtomicLong: JvmName = JvmName(JavaUtil ::: List("concurrent", "atomic"), "AtomicLong")
   val Boolean: JvmName = JvmName(JavaLang, "Boolean")
@@ -84,7 +85,8 @@ object JvmName {
   val Error: JvmName = JvmName(JavaLang, "Error")
   val Exception: JvmName = JvmName(JavaLang, "Exception")
   val Float: JvmName = JvmName(JavaLang, "Float")
-  val IntFunction: JvmName = JvmName(JavaUtil ::: List("function"), "IntFunction")
+  val IntFunction: JvmName = JvmName(JavaUtilFunction, "IntFunction")
+  val IntUnaryOperator: JvmName = JvmName(JavaUtilFunction, "IntUnaryOperator")
   val Integer: JvmName = JvmName(JavaLang, "Integer")
   val Long: JvmName = JvmName(JavaLang, "Long")
   val Math: JvmName = JvmName(JavaLang, "Math")

--- a/main/test/flix/Test.Exp.Jvm.InvokeConstructor.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeConstructor.flix
@@ -59,4 +59,9 @@ namespace Test/Exp/Jvm/InvokeConstructor {
     def testInvokeStaticNestedConstructor01(): ##java.util.Locale$Builder \ IO =
         import new java.util.Locale$Builder(): ##java.util.Locale$Builder as newBuilder;
         newBuilder()
+
+    @test
+    def testInvokeConstructorWithArrayParam(): ##java.net.URLClassLoader \ IO =
+        import new java.net.URLClassLoader(Array[##java.net.URL, _]): ##java.net.URLClassLoader \ IO as newClassLoader;
+        newClassLoader([])
 }

--- a/main/test/flix/Test.Exp.Jvm.InvokeStaticMethod.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeStaticMethod.flix
@@ -53,4 +53,11 @@ namespace Test/Exp/Jvm/InvokeStaticMethod {
     def testInvokeInheritedStaticMethod01(): Bool =
         import static flix.test.TestClassWithInheritedMethod.staticMethod(Int32): Int32 \ {};
         staticMethod(1) == 2
+
+    @test
+    def testInvokeStaticMethodWithArrayParam(): Bool \ IO =
+        import static java.util.Arrays.fill(Array[##java.lang.Object, _], ##java.lang.Object): Unit \ IO;
+        let a = ["this", "that"];
+        fill(a as Array[##java.lang.Object, _], "foo" as ##java.lang.Object);
+        true
 }

--- a/main/test/flix/Test.Java.Function.flix
+++ b/main/test/flix/Test.Java.Function.flix
@@ -9,22 +9,24 @@ namespace Test/Java/Function {
    def testIntFunction(): Bool \ IO = {
         import static java.util.stream.IntStream.of(Int32): IntStream \ IO;
         import java.util.stream.IntStream.mapToObj(IntFunction): Stream \ IO;
-        import java.util.stream.Stream.count(): Int64 \ IO;
-        import java.util.stream.Stream.distinct(): Stream \ IO;
-        import new java.lang.Object(): Object \ IO as newObject;
-        let stream0 = of(1);
-        let stream1 = mapToObj(stream0, _ -> newObject());
-        count(distinct(stream1)) == 1i64
+        import java.util.stream.Stream.findFirst(): ##java.util.Optional \ IO;
+        import java.util.Optional.get(): Object;
+        import java.lang.Object.toString(): String;
+        let stream0 = of(42);
+        let f = i -> new Object {
+            def toString(_this: Object): String = "${i}"
+        };
+        let stream1 = mapToObj(stream0, f);
+        toString(get(findFirst(stream1))) == "42"
     }
 
-//   @Test
-//   def testUnaryIntOperator(): Bool \ IO = {
-//        import static java.util.stream.IntStream.of(Int32): IntStream \ IO;
-//        import java.util.stream.IntStream.map(IntUnaryOperator): IntStream \ IO;
-//        import java.util.stream.IntStream.count(): Int64 \ IO;
-//        import java.util.stream.IntStream.distinct(): IntStream \ IO;
-//        let stream0 = of(1);
-//        let stream1 = map(stream0, _ -> 123 as \ IO); // TODO change to upcast
-//        count(distinct(stream1)) == 1i64
-//    }
+  @Test
+  def testUnaryIntOperator(): Bool \ IO = {
+       import static java.util.stream.IntStream.of(Int32): IntStream \ IO;
+       import java.util.stream.IntStream.map(IntUnaryOperator): IntStream \ IO;
+       import java.util.stream.IntStream.sum(): Int32 \ IO;
+       let stream0 = of(5);
+       let stream1 = map(stream0, upcast(i -> i+7));
+       sum(stream1) == 12
+   }
 }


### PR DESCRIPTION
This fixes calling a constructor which takes an array argument (calling methods and static methods with array arguments already works).

The problem was that the code to put the arguments on the stack for constructors was different from the equivalent code for methods and static methods. This PR pulls that code out into a separate method to ensure that it's always done the same way.